### PR TITLE
AO-219: Upgrade to .NET 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build-env
 WORKDIR /app
 COPY Worker ./Worker
 RUN dotnet publish Worker -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 as runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble as runtime
 COPY --from=build-env /app/out /
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Worker-95F4088B-EB25-4C4A-8197-1F7E21C8AA42</UserSecretsId>

--- a/action.yml
+++ b/action.yml
@@ -4,18 +4,25 @@ description: 'Send a notfication to MS Teams indicating the result of the Github
 
 inputs:
   description:
+    description: "Description field of the notification"
     required: true
   workflow:
+    description: "Workflow name"
     required: true
   webhook:
+    description: "Webhook URL"
     required: true
   job:
+    description: "Job data"
     required: true
   title_override:
+    description: "Override value for the title field"
     required: false
   steps:
+    description: "Step data"
     required: false
   needs:
+    description: "Job dependencies"
     required: false
 runs:
   using: 'docker'


### PR DESCRIPTION
## Description

- Migrate to .NET 10 to fix 403 errors with MCR registry

## Related PRs

- Broke on https://github.com/acresecurity/SysOps-WatchDogTests/pull/27
